### PR TITLE
Issue #SC-1746 merging to 2.9.1 and re-checking out the segregating u…

### DIFF
--- a/data-products/src/main/scala/org/sunbird/analytics/job/report/StateAdminReportJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/job/report/StateAdminReportJob.scala
@@ -15,6 +15,8 @@ import org.ekstep.analytics.framework.util.JSONUtils
 import org.ekstep.analytics.framework.JobContext
 import org.ekstep.analytics.framework.StorageConfig
 import org.ekstep.analytics.framework.OutputDispatcher
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
 
 case class ValidatedUserDistrictSummary(index: Int, districtName: String, blocks: Long, schools: Long, registered: Long)
 case class UserStatus(id: Long, status: String)
@@ -159,12 +161,21 @@ object StateAdminReportJob extends optional.Application with IJob with StateAdmi
       * @param reportDF
       * @param url
       */
-    def saveUserDetailsReport(reportDF: DataFrame, channelSlugDF: DataFrame, storageConfig: StorageConfig): Unit = {
+    def saveUserDetailsReport(reportDF: DataFrame, channelSlugDF: DataFrame, storageConfig: StorageConfig) (implicit spark: SparkSession): Unit = {
+        import spark.implicits._
         // List of fields available
         //channel,userextid,addedby,claimedon,claimstatus,createdon,email,name,orgextid,phone,processid,updatedon,userid,userids,userstatus
-
-        reportDF.join(channelSlugDF, reportDF.col("channel") === channelSlugDF.col("channel"), "left_outer").select(
+        val userDetailReport = reportDF.withColumn("shadow_user_status",
+            when($"claimstatus" === UnclaimedStatus.id, lit(UnclaimedStatus.status))
+            .when($"claimstatus" === ClaimedStatus.id, lit(ClaimedStatus.status))
+            .when($"claimstatus" === FailedStatus.id, lit(FailedStatus.status))
+            .when($"claimstatus" === RejectedStatus.id, lit(RejectedStatus.status))
+            .when($"claimstatus" === MultiMatchStatus.id, lit(MultiMatchStatus.status))
+            .when($"claimstatus" === OrgExtIdMismatch.id, lit(FailedStatus.status))
+            .when($"claimstatus" === Eligible.id, lit(Eligible.status)))
+        userDetailReport.join(channelSlugDF, reportDF.col("channel") === channelSlugDF.col("channel"), "left_outer").select(
               col("slug"),
+              col("shadow_user_status"),
               col("userextid").as("User external id"),
               col("userstatus").as("User account status"),
               col("userid").as("User id"),
@@ -173,10 +184,11 @@ object StateAdminReportJob extends optional.Application with IJob with StateAdmi
               col("orgextid").as("School external id"),
               col("claim_status").as("Claimed status"),
               col("createdon").as("Created on"),
-              col("updatedon").as("Last updated on")).filter(col(colName = "slug").isNotNull)
-          .saveToBlobStore(storageConfig, "csv", "user-detail", Option(Map("header" -> "true")), Option(Seq("slug")))
+              col("updatedon").as("Last updated on")).filter(col(colName ="shadow_user_status").
+            isin(lit(UnclaimedStatus.status),lit(ClaimedStatus.status),lit(RejectedStatus.status),lit(FailedStatus.status),lit(MultiMatchStatus.status))).filter(col(colName = "slug").isNotNull)
+          .saveToBlobStore(storageConfig, "csv", "user-detail", Option(Map("header" -> "true")), Option(Seq("shadow_user_status","slug")))
           
-        JobLogger.log(s"StateAdminReportJob: user-details report records count = ${reportDF.count()}", None, INFO)
+        JobLogger.log(s"StateAdminReportJob: user-details report records count = ${userDetailReport.count()}", None, INFO)
     }
 
     def saveUserValidatedSummaryReport(reportDF: DataFrame, storageConfig: StorageConfig): Unit = {
@@ -212,7 +224,6 @@ object StateAdminReportJob extends optional.Application with IJob with StateAdmi
                 "accounts_failed",
                 col(FailedStatus.status) + col(MultiMatchStatus.status) + col(OrgExtIdMismatch.status)).filter(col(colName = "slug").isNotNull)
             .saveToBlobStore(storageConfig, "json", "user-summary", None, Option(Seq("slug")))
-        
         JobLogger.log(s"StateAdminReportJob: user-summary report records count = ${correctedReportDF.count()}", None, INFO)
     }
 

--- a/data-products/src/test/scala/org/sunbird/analytics/job/report/TestStateAdminReportJob.scala
+++ b/data-products/src/test/scala/org/sunbird/analytics/job/report/TestStateAdminReportJob.scala
@@ -48,13 +48,13 @@ class TestStateAdminReportJob extends BaseReportSpec with MockFactory {
     val districtName = apslug.select("districtName").collect().map(_ (0)).toList
     assert(districtName(0) === "GULBARGA")
     //checking reports were created under slug folder
-    val userDetail = new File("src/test/resources/admin-user-reports/user-detail/ApSlug.csv")
+    val userClaimedDetail = new File("src/test/resources/admin-user-reports/user-detail/CLAIMED/ApSlug.csv")
     val stateUserDetail = new File("src/test/resources/admin-user-reports/validated-user-detail-state/ApSlug.csv");
     val userSummary = new File("src/test/resources/admin-user-reports/user-summary/ApSlug.json")
     val validateUserDetail = new File("src/test/resources/admin-user-reports/validated-user-detail/ApSlug.csv")
     val validateUserSummary = new File("src/test/resources/admin-user-reports/validated-user-summary/ApSlug.json")
     val validateUserDstSummary = new File("src/test/resources/admin-user-reports/validated-user-summary-district/ApSlug.json");
-    assert(userDetail.exists() === true)
+    assert(userClaimedDetail.exists() === true)
     assert(userSummary.exists() === true)
     assert(validateUserDetail.exists() === true)
     assert(validateUserSummary.exists() === true)


### PR DESCRIPTION
merging to 2.9.1 and re-checking out the segregating user-details file changes to multiple files based on claim status

1. PR 69 - 2.10.0 -> 2.9.0
2. PR 79 Revert of 69
3. PR 80 Bring back functionality into 2.9.1