### PR TITLE
Issue #SB-19637 feat: filter on content mimetype

### DIFF
--- a/python-scripts/src/main/python/dataproducts/resources/queries/content_list.py
+++ b/python-scripts/src/main/python/dataproducts/resources/queries/content_list.py
@@ -14,8 +14,8 @@ def init():
                 },
                 {
                     "type": "in",
-                    "dimension": "contentType",
-                    "values": ["Resource", "ExplanationResource", "FocusSpot", "PracticeQuestionSet", "eTextBook", "LearningOutcomeDefinition", "PracticeResource", "ExperientialResource", "SelfAssess", "CuriosityQuestionSet"]
+                    "dimension": "mimeType",
+                    "values": "mimetype_filter"
                 },
                 {
                     "type": "in",
@@ -34,26 +34,13 @@ def init():
             "name",
             "channel",
             "contentType",
-            "mediaType",
             "mimeType",
-            "objectType",
-            "resourceType",
             "status",
-            "author",
             "creator",
             "createdOn",
             "lastPublishedOn",
-            "lastSubmittedOn",
-            "lastUpdatedOn",
             "me_averageRating",
-            "me_totalRatings",
-            "me_totalDownloads",
-            "me_totalTimeSpentInApp",
-            "me_totalTimeSpentInPortal",
-            "me_totalTimeSpentInDesktop",
-            "me_totalPlaySessionCountInApp",
-            "me_totalPlaySessionCountInPortal",
-            "me_totalPlaySessionCountInDesktop"
+            "me_totalRatings"
         ]
     }
     """

--- a/python-scripts/src/main/python/dataproducts/resources/queries/content_list_v1.py
+++ b/python-scripts/src/main/python/dataproducts/resources/queries/content_list_v1.py
@@ -1,0 +1,59 @@
+def init():
+    return """
+    {
+        "queryType": "scan",
+        "dataSource": "content-model-snapshot",
+        "intervals": "1901-01-01T00:00:00+00:00/2101-01-01T00:00:00+00:00",
+        "filter": {
+            "type": "and",
+            "fields": [
+                {
+                    "type": "selector",
+                    "dimension": "objectType",
+                    "value": "Content"
+                },
+                {
+                    "type": "in",
+                    "dimension": "contentType",
+                    "values": ["Resource", "ExplanationResource", "FocusSpot", "PracticeQuestionSet", "eTextBook", "LearningOutcomeDefinition", "PracticeResource", "ExperientialResource", "SelfAssess", "CuriosityQuestionSet"]
+                },
+                {
+                    "type": "in",
+                    "dimension": "status",
+                    "values": ["Live"],
+                    "extractionFn": null
+                }
+            ]
+        },
+        "columns": [
+            "identifier",
+            "board",
+            "medium",
+            "gradeLevel",
+            "subject",
+            "name",
+            "channel",
+            "contentType",
+            "mediaType",
+            "mimeType",
+            "objectType",
+            "resourceType",
+            "status",
+            "author",
+            "creator",
+            "createdOn",
+            "lastPublishedOn",
+            "lastSubmittedOn",
+            "lastUpdatedOn",
+            "me_averageRating",
+            "me_totalRatings",
+            "me_totalDownloads",
+            "me_totalTimeSpentInApp",
+            "me_totalTimeSpentInPortal",
+            "me_totalTimeSpentInDesktop",
+            "me_totalPlaySessionCountInApp",
+            "me_totalPlaySessionCountInPortal",
+            "me_totalPlaySessionCountInDesktop"
+        ]
+    }
+    """

--- a/python-scripts/src/main/python/dataproducts/resources/queries/content_list_v2.py
+++ b/python-scripts/src/main/python/dataproducts/resources/queries/content_list_v2.py
@@ -15,7 +15,7 @@ def init():
                 {
                     "type": "in",
                     "dimension": "mimeType",
-                    "values": "mimetype_filter"
+                    "values": []
                 },
                 {
                     "type": "in",

--- a/python-scripts/src/main/python/dataproducts/resources/queries/content_plays.py
+++ b/python-scripts/src/main/python/dataproducts/resources/queries/content_plays.py
@@ -42,19 +42,9 @@ def init():
                     "value": "play"
                 },
                 {
-                    "type": "or",
-                    "fields": [
-                        {
-                            "type": "selector",
-                            "dimension": "dimensions_pdata_id",
-                            "value": "$app"
-                        },
-                        {
-                            "type": "selector",
-                            "dimension": "dimensions_pdata_id",
-                            "value": "$portal"
-                        }
-                    ]
+                    "type": "in",
+                    "dimension": "dimensions_pdata_id",
+                    "values": ["$app", "$portal"]
                 }
             ]
         }

--- a/python-scripts/src/main/python/dataproducts/services/consumption/content_consumption.py
+++ b/python-scripts/src/main/python/dataproducts/services/consumption/content_consumption.py
@@ -285,7 +285,7 @@ class ContentConsumption:
             self.config = json.loads(f.read())
         get_tenant_info(result_loc_=result_loc, org_search_=org_search, date_=execution_date)
         print("Success::Tenant info")
-        get_content_model(result_loc_=result_loc, druid_=druid, date_=execution_date)
+        get_content_model(result_loc_=result_loc, druid_=druid, date_=execution_date, config_=self.config)
         print("Success::content model snapshot")
         get_tb_content_mapping(result_loc_=result_loc, date_=execution_date, content_search_=content_search)
         print("Success::TB Content Map")

--- a/python-scripts/src/main/python/dataproducts/services/consumption/content_consumption.py
+++ b/python-scripts/src/main/python/dataproducts/services/consumption/content_consumption.py
@@ -58,7 +58,7 @@ class ContentConsumption:
             else:
                 end_date = date_
             get_content_plays(result_loc_=result_loc_.joinpath(date_.strftime('%Y-%m-%d')), start_date_=start_date,
-                              end_date_=end_date, druid_=druid_rollup_, config_=config)
+                              end_date_=end_date, druid_=druid_rollup_, config_=config, version_='v1')
             start_date = end_date
         spark = SparkSession.builder.appName('content_consumption').master("local[*]").getOrCreate()
         content_plays = spark.read.csv(str(result_loc_.joinpath(date_.strftime('%Y-%m-%d'), 'content_plays_*.csv')),
@@ -161,7 +161,7 @@ class ContentConsumption:
         result_loc_.joinpath(date_.strftime('%Y-%m-%d')).mkdir(exist_ok=True)
         start_date = date_ - timedelta(days=7)
         get_content_plays(result_loc_=result_loc_.joinpath(date_.strftime('%Y-%m-%d')), start_date_=start_date,
-                          end_date_=date_, druid_=druid_rollup_, config_=config)
+                          end_date_=date_, druid_=druid_rollup_, config_=config, version_='v2')
         content_plays = pd.read_csv(
             result_loc_.joinpath(date_.strftime('%Y-%m-%d'), 'content_plays_{}.csv'.format(date_.strftime('%Y-%m-%d'))))
         content_plays = content_plays.groupby(['object_id', 'dimensions_pdata_id'])[
@@ -285,7 +285,8 @@ class ContentConsumption:
             self.config = json.loads(f.read())
         get_tenant_info(result_loc_=result_loc, org_search_=org_search, date_=execution_date)
         print("Success::Tenant info")
-        get_content_model(result_loc_=result_loc, druid_=druid, date_=execution_date, config_=self.config)
+        get_content_model(result_loc_=result_loc, druid_=druid, date_=execution_date, config_=self.config,
+                          version_='v2')
         print("Success::content model snapshot")
         get_tb_content_mapping(result_loc_=result_loc, date_=execution_date, content_search_=content_search)
         print("Success::TB Content Map")

--- a/python-scripts/src/main/python/dataproducts/util/utils.py
+++ b/python-scripts/src/main/python/dataproducts/util/utils.py
@@ -258,13 +258,14 @@ def verify_state_district(loc_map_path_, state_, df_):
     return df_
 
 
-def get_content_model(result_loc_, druid_, date_, config_, status_=["Live"]):
+def get_content_model(result_loc_, druid_, date_, config_, version_, status_=["Live"]):
     """
     get current content model snapshot
     :param result_loc_: pathlib.Path object to store resultant CSV at
     :param druid_: host ip and port for druid broker
     :param date_: datetime object to pass in path
     :param config_: pass the mime type filters
+    :param version_: differentiate between versions of query. values in ['v1', 'v2']
     :param status_: status of the content which has to retrieved
     :return: None
     """
@@ -273,9 +274,13 @@ def get_content_model(result_loc_, druid_, date_, config_, status_=["Live"]):
             'Content-Type': "application/json"
         }
         url = "{}druid/v2/".format(druid_)
-        qr = content_list.init()
+        if version_ == 'v1':
+            qr = content_list_v1.init()
+        elif version_ == 'v2':
+            qr = content_list_v2.init()
         qr = json.loads(qr)
-        qr['filter']['fields'][1]['values'] = config_['content']['mimeType']
+        if version_ == 'v2':
+            qr['filter']['fields'][1]['values'] = config_['content']['mimeType']
         qr['filter']['fields'][2]['values'] = status_
         response = requests.request("POST", url, data=json.dumps(qr), headers=headers)
         result = response.json()
@@ -283,25 +288,8 @@ def get_content_model(result_loc_, druid_, date_, config_, status_=["Live"]):
         for segment in result:
             response_list.append(pd.DataFrame(segment['events']))
         content_model = pd.concat(response_list)
-        rename_mimetype = {
-            'application/epub': 'Document',
-            'application/octet-stream': 'Document',
-            'application/pdf': 'Document',
-            'application/msword': 'Document',
-            'application/vnd.ekstep.ecml-archive': 'Interactive Content',
-            'application/vnd.ekstep.h5p-archive': 'Interactive Content',
-            'application/vnd.ekstep.html-archive': 'Interactive Content',
-            'text/x-url': 'Document',
-            'video/3gpp': 'Video',
-            'video/avi': 'Video',
-            'video/ogg': 'Video',
-            'video/quicktime': 'Video',
-            'video/mp4': 'Video',
-            'video/mpeg': 'Video',
-            'video/webm': 'Video',
-            'video/x-youtube': 'YouTube'
-        }
-        content_model['mimeType'].replace(rename_mimetype, inplace=True)
+        if version_ == 'v2':
+            content_model['mimeType'].replace(config_['rename_mimetype'], inplace=True)
         content_model.to_csv(result_loc_.joinpath(date_.strftime('%Y-%m-%d'), 'content_model_snapshot.csv'),
                              index=False, encoding='utf-8-sig')
         post_data_to_blob(result_loc_.joinpath(date_.strftime('%Y-%m-%d'), 'content_model_snapshot.csv'), backup=True)
@@ -549,7 +537,7 @@ def get_courses(result_loc_, druid_, date_):
     post_data_to_blob(result_loc_.joinpath(date_.strftime('%Y-%m-%d'), 'courses.csv'), backup=True)
 
 
-def get_content_plays(result_loc_, start_date_, end_date_, druid_, config_):
+def get_content_plays(result_loc_, start_date_, end_date_, druid_, config_, version_):
     """
     Get content plays and timespent by content id.
     :param result_loc_: local path to store resultant csv
@@ -557,6 +545,7 @@ def get_content_plays(result_loc_, start_date_, end_date_, druid_, config_):
     :param end_date_: datetime object used for druid query
     :param druid_: druid broker ip and port in http://ip:port/ format
     :param config_: Platform cofigs for druid query
+    :param version_: to differentiate version of query. value in ['v1', 'v2']
     :return: None
     """
     headers = {
@@ -569,7 +558,7 @@ def get_content_plays(result_loc_, start_date_, end_date_, druid_, config_):
     query = query.replace('$app', config_['context']['pdata']['id']['app'])
     query = query.replace('$portal', config_['context']['pdata']['id']['portal'])
     query = json.loads(query)
-    if start_date_ > datetime(2020, 7, 2):
+    if version_ == 'v2':
         query['filter']['fields'].append(
             {
                 "type": "in",

--- a/python-scripts/src/main/python/dataproducts/util/utils.py
+++ b/python-scripts/src/main/python/dataproducts/util/utils.py
@@ -258,13 +258,14 @@ def verify_state_district(loc_map_path_, state_, df_):
     return df_
 
 
-def get_content_model(result_loc_, druid_, date_, status_=["Live"]):
+def get_content_model(result_loc_, druid_, date_, config_, status_=["Live"]):
     """
     get current content model snapshot
     :param result_loc_: pathlib.Path object to store resultant CSV at
     :param druid_: host ip and port for druid broker
     :param date_: datetime object to pass in path
-    :status_: status of the content which has to retrieved
+    :param config_: pass the mime type filters
+    :param status_: status of the content which has to retrieved
     :return: None
     """
     try:
@@ -274,6 +275,7 @@ def get_content_model(result_loc_, druid_, date_, status_=["Live"]):
         url = "{}druid/v2/".format(druid_)
         qr = content_list.init()
         qr = json.loads(qr)
+        qr['filter']['fields'][1]['values'] = config_['content']['mimeType']
         qr['filter']['fields'][2]['values'] = status_
         response = requests.request("POST", url, data=json.dumps(qr), headers=headers)
         result = response.json()
@@ -281,6 +283,25 @@ def get_content_model(result_loc_, druid_, date_, status_=["Live"]):
         for segment in result:
             response_list.append(pd.DataFrame(segment['events']))
         content_model = pd.concat(response_list)
+        rename_mimetype = {
+            'application/epub': 'Document',
+            'application/octet-stream': 'Document',
+            'application/pdf': 'Document',
+            'application/msword': 'Document',
+            'application/vnd.ekstep.ecml-archive': 'Interactive Content',
+            'application/vnd.ekstep.h5p-archive': 'Interactive Content',
+            'application/vnd.ekstep.html-archive': 'Interactive Content',
+            'text/x-url': 'Document',
+            'video/3gpp': 'Video',
+            'video/avi': 'Video',
+            'video/ogg': 'Video',
+            'video/quicktime': 'Video',
+            'video/mp4': 'Video',
+            'video/mpeg': 'Video',
+            'video/webm': 'Video',
+            'video/x-youtube': 'YouTube'
+        }
+        content_model['mimeType'].replace(rename_mimetype, inplace=True)
         content_model.to_csv(result_loc_.joinpath(date_.strftime('%Y-%m-%d'), 'content_model_snapshot.csv'),
                              index=False, encoding='utf-8-sig')
         post_data_to_blob(result_loc_.joinpath(date_.strftime('%Y-%m-%d'), 'content_model_snapshot.csv'), backup=True)
@@ -547,7 +568,16 @@ def get_content_plays(result_loc_, start_date_, end_date_, druid_, config_):
     query = query.replace('$end_date', end_date_.strftime('%Y-%m-%dT00:00:00+00:00'))
     query = query.replace('$app', config_['context']['pdata']['id']['app'])
     query = query.replace('$portal', config_['context']['pdata']['id']['portal'])
-    response = requests.post(url, data=query, headers=headers)
+    query = json.loads(query)
+    if start_date_ > datetime(2020, 7, 2):
+        query['filter']['fields'].append(
+            {
+                "type": "in",
+                "dimension": "content_mimetype",
+                "values": config_['content']['mimeType']
+            },
+        )
+    response = requests.post(url, data=json.dumps(query), headers=headers)
     result = response.json()
     data = pd.DataFrame([x['event'] for x in result])
     data.to_csv(result_loc_.joinpath(end_date_.strftime('content_plays_%Y-%m-%d.csv')), index=False)


### PR DESCRIPTION
Filtering the content consumption report on mimetype as provided on https://project-sunbird.atlassian.net/browse/SB-19637
The mimetype filters are stored in a config file on blob store as the filters may change.
Added functionality in fetching content plays to filter on mimetype if the query date range is after 2 July (when content mimetype was indexed in druid datasource.
