### PR TITLE
Report job update

### DIFF
--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/OnDemandExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/OnDemandExhaustJob.scala
@@ -43,8 +43,8 @@ trait OnDemandExhaustJob {
     val encoder = Encoders.product[JobRequest]
     val reportConfigsDf = spark.read.jdbc(url, requestsTable, connProperties)
       .where(col("job_id") === jobId && col("iteration") < 3).filter(col("status").isin(jobStatus:_*));
-    val distinctRequestsDf = reportConfigsDf.select("*").dropDuplicates("request_data.batchId")
-    val duplicateRequestsDf = reportConfigsDf.except(distinctRequestsDf)
+    val distinctRequestsDf = reportConfigsDf.dropDuplicates("tag")
+    val duplicateRequestsDf = reportConfigsDf.exceptAll(distinctRequestsDf)
     val duplicateReq = duplicateRequestsDf.withColumn("status", lit("ABORTED")).withColumn("err_message", lit("Duplicate batch request")).as[JobRequest](encoder).collect()
     updateRequests(duplicateReq)
     val requests = distinctRequestsDf.withColumn("status", lit("PROCESSING")).as[JobRequest](encoder).collect()

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/OnDemandExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/OnDemandExhaustJob.scala
@@ -45,11 +45,10 @@ trait OnDemandExhaustJob {
       .where(col("job_id") === jobId && col("iteration") < 3).filter(col("status").isin(jobStatus:_*));
     
     val requests = reportConfigsDf.withColumn("status", lit("PROCESSING")).as[JobRequest](encoder).collect()
-    updateRequests(requests)
     requests;
   }
   
-  private def updateRequests(requests: Array[JobRequest]) = {
+  def updateRequests(requests: Array[JobRequest]) = {
     if(requests != null && requests.length > 0) {
       val dbc:Connection = DriverManager.getConnection(url, connProperties.getProperty("user"), connProperties.getProperty("password"));
       dbc.setAutoCommit(true);

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/OnDemandExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/OnDemandExhaustJob.scala
@@ -45,7 +45,7 @@ trait OnDemandExhaustJob {
       .where(col("job_id") === jobId && col("iteration") < 3).filter(col("status").isin(jobStatus:_*));
     val distinctRequestsDf = reportConfigsDf.dropDuplicates("tag")
     val duplicateRequestsDf = reportConfigsDf.exceptAll(distinctRequestsDf)
-    val duplicateReq = duplicateRequestsDf.withColumn("status", lit("ABORTED")).withColumn("err_message", lit("Duplicate batch request")).as[JobRequest](encoder).collect()
+    val duplicateReq = duplicateRequestsDf.withColumn("status", lit("ABORTED")).withColumn("err_message", lit("Duplicate request tag")).as[JobRequest](encoder).collect()
     updateRequests(duplicateReq)
     val requests = distinctRequestsDf.withColumn("status", lit("PROCESSING")).as[JobRequest](encoder).collect()
     requests;

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -116,6 +116,7 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
           val res = CommonUtil.time(processRequest(request, custodianOrgId, userCachedDF))
           JobLogger.log("The Request is processed", Some(Map("requestId" -> request.request_id, "timeTaken" -> res._1, "requestStatus" -> res._2.status, "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
           saveRequests(storageConfig, Array(res._2))
+          if(totalRequests.get() == 2) throw new NullPointerException("Custom null")
           res._2
         } else {
           JobLogger.log("Invalid Request", Some(Map("requestId" -> request.request_id, "requestStatus" -> "FAILED", "remainingRequest" -> totalRequests.getAndDecrement())), INFO)

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -122,7 +122,7 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
         } else {
           JobLogger.log("Invalid Request", Some(Map("requestId" -> request.request_id, "requestStatus" -> "FAILED", "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
           val failedRequest = markRequestAsFailed(request, "Invalid Request")
-          saveRequests(storageConfig, Array(failedRequest))
+          updateRequests(Array(failedRequest))
           failedRequest
         }
       }
@@ -131,7 +131,7 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
           JobLogger.log(s"The Request is failed to process due to ${ex.getMessage}", Some(Map("requestId" -> request.request_id, "requestStatus" -> "FAILED",  "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
           ex.printStackTrace()
           val failedRequest = markRequestAsFailed(request, ex.getMessage)
-          updateRequests(Array(failedRequest)) // Set the request status to PROCESSING when it picked up for processing
+          updateRequests(Array(failedRequest))
           failedRequest
         }
       }

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -115,7 +115,12 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
           if (validateRequest(request)) {
             updateRequests(Array(request)) // Set the request status to PROCESSING for each request
             val res = CommonUtil.time(processRequest(request, custodianOrgId, userCachedDF))
-            JobLogger.log("The Request is processed", Some(Map("requestId" -> request.request_id, "timeTaken" -> res._1, "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
+            val count = totalRequests.getAndDecrement()
+            JobLogger.log("The Request is processed", Some(Map("requestId" -> request.request_id, "timeTaken" -> res._1, "remainingRequest" -> count)), INFO)
+            if(count == 2) {
+              println("counttt" + count)
+              throw new Exception("TestException")
+            }
             res._2
           } else {
             JobLogger.log("Invalid Request", Some(Map("requestId" -> request.request_id, "remainingRequest" -> totalRequests.getAndDecrement())), INFO)

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -108,28 +108,32 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
     val storageConfig = getStorageConfig(config, "");
     val requests = getRequests(jobId());
     val totalRequests = new AtomicInteger(requests.length)
-    val result: Array[JobRequest] = for (request <- requests) yield {
+    var result: Array[JobRequest] = null
+    try {
+      result = for (request <- requests) yield {
         try {
-        if (validateRequest(request)) {
-          updateRequests(Array(request)) // Set the request status to PROCESSING for each request
-          val res = CommonUtil.time(processRequest(request, custodianOrgId, userCachedDF))
-          JobLogger.log("The Request is processed", Some(Map("requestId" -> request.request_id, "timeTaken" -> res._1, "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
-          res._2
-        } else {
-          JobLogger.log("Invalid Request", Some(Map("requestId" -> request.request_id, "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
-          markRequestAsFailed(request, "Invalid request")
+          if (validateRequest(request)) {
+            updateRequests(Array(request)) // Set the request status to PROCESSING for each request
+            val res = CommonUtil.time(processRequest(request, custodianOrgId, userCachedDF))
+            JobLogger.log("The Request is processed", Some(Map("requestId" -> request.request_id, "timeTaken" -> res._1, "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
+            res._2
+          } else {
+            JobLogger.log("Invalid Request", Some(Map("requestId" -> request.request_id, "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
+            markRequestAsFailed(request, "Invalid request")
+          }
+        }
+        catch {
+          case ex: Exception => {
+            println("Exception occurred..")
+            ex.printStackTrace()
+            markRequestAsFailed(request, "Invalid request")
+          }
         }
       }
-      catch {
-        case ex: Exception => {
-          println("Exception occurred..")
-          ex.printStackTrace()
-          markRequestAsFailed(request, "Invalid request")
-        }
-      } finally {
-        println("results are" + JSONUtils.serialize(result))
-        logTime(saveRequests(storageConfig, result), s"Total time taken to save the ${result.length} requests (download, zipping, encryption, upload, postgres save) - "); // Updating the postgress table
-      }
+    }
+    finally {
+      println("results are" + JSONUtils.serialize(result))
+      logTime(saveRequests(storageConfig, result), s"Total time taken to save the ${result.length} requests (download, zipping, encryption, upload, postgres save) - "); // Updating the postgress table
     }
     Metrics(totalRequests = Some(requests.length), failedRequests = Some(result.count(x => x.status.toUpperCase() == "FAILED")), successRequests = Some(result.count(x => x.status.toUpperCase == "SUCCESS")))
   }

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -100,7 +100,7 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
     val searchFilter = modelParams.get("searchFilter").asInstanceOf[Option[Map[String, AnyRef]]];
     val collectionBatches = getCollectionBatches(batchId, batchFilter, searchFilter, custodianOrgId, "System");
     val result: List[CollectionBatchResponse] = processBatches(userCachedDF, collectionBatches);
-    result.foreach(f =>  JobLogger.log(s"Batch Status: ${f.status}, batchId: ${f.batchId}, time: ${f.execTime}, message: ${f.statusMsg}, location: ${f.file} ", None, INFO));
+    result.foreach(f => JobLogger.log("Batch Status", Some(Map("status" -> f.status, "batchId" -> f.batchId, "executionTime" -> f.execTime, "message" -> f.statusMsg, "location" -> f.file)), INFO));
     Metrics(totalRequests = Some(result.length), failedRequests = Some(result.count(x => x.status.toLowerCase() == "FAILED")), successRequests = Some(result.count(x => x.status.toLowerCase() == "SUCCESS")))
   }
 

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -122,9 +122,12 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
         }
       }
     } catch {
-      case ex: Exception => ex.printStackTrace()
-        null
+      case ex: Exception => {
+        println("Exception occurred..")
+        ex.printStackTrace()
+      }
     } finally {
+      println("results are" + JSONUtils.serialize(result))
       logTime(saveRequests(storageConfig, result), s"Total time taken to save the ${result.length} requests (download, zipping, encryption, upload, postgres save) - "); // Updating the postgress table
     }
     Metrics(totalRequests = Some(requests.length), failedRequests = Some(result.count(x => x.status.toUpperCase() == "FAILED")), successRequests = Some(result.count(x => x.status.toUpperCase == "SUCCESS")))

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -131,7 +131,7 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
           JobLogger.log(s"The Request is failed to process due to ${ex.getMessage}", Some(Map("requestId" -> request.request_id, "requestStatus" -> "FAILED",  "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
           ex.printStackTrace()
           val failedRequest = markRequestAsFailed(request, ex.getMessage)
-          saveRequests(storageConfig, Array(failedRequest))
+          updateRequests(Array(failedRequest)) // Set the request status to PROCESSING when it picked up for processing
           failedRequest
         }
       }

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -114,9 +114,10 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
         if (validateRequest(request)) {
           updateRequests(Array(request)) // Set the request status to PROCESSING when it picked up for processing
           val res = CommonUtil.time(processRequest(request, custodianOrgId, userCachedDF))
-          JobLogger.log("The Request is processed", Some(Map("requestId" -> request.request_id, "timeTaken" -> res._1, "requestStatus" -> res._2.status, "remainingRequest" -> totalRequests.getAndDecrement())), INFO)
+          val rem = totalRequests.getAndDecrement()
+          JobLogger.log("The Request is processed", Some(Map("requestId" -> request.request_id, "timeTaken" -> res._1, "requestStatus" -> res._2.status, "remainingRequest" -> rem)), INFO)
           saveRequests(storageConfig, Array(res._2))
-          if(totalRequests.get() == 2) throw new NullPointerException("Custom null")
+          if(rem == 2) throw new NullPointerException("Custom null")
           res._2
         } else {
           JobLogger.log("Invalid Request", Some(Map("requestId" -> request.request_id, "requestStatus" -> "FAILED", "remainingRequest" -> totalRequests.getAndDecrement())), INFO)

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -101,7 +101,7 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
     val collectionBatches = getCollectionBatches(batchId, batchFilter, searchFilter, custodianOrgId, "System");
     val result: List[CollectionBatchResponse] = processBatches(userCachedDF, collectionBatches);
     result.foreach(f => JobLogger.log("Batch Status", Some(Map("status" -> f.status, "batchId" -> f.batchId, "executionTime" -> f.execTime, "message" -> f.statusMsg, "location" -> f.file)), INFO));
-    Metrics(totalRequests = Some(result.length), failedRequests = Some(result.count(x => x.status.toUpperCase() == "FAILED")), successRequests = Some(result.count(x => x.status.toUpperCase() == "SUCCESS")))
+    Metrics(totalRequests = Some(result.length), failedRequests = Some(result.count(x => x.status.toUpperCase() == "FAILED")), successRequests = Some(result.count(x => x.status.toUpperCase() == "SUCCESS")), Some(0))
   }
 
   def executeOnDemand(custodianOrgId: String, userCachedDF: DataFrame)(implicit spark: SparkSession, fc: FrameworkContext, config: JobConfig): Metrics = {

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -59,7 +59,7 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
     init()
     try {
       val res = CommonUtil.time(execute());
-      JobLogger.end(s"$jobName completed execution", "SUCCESS", Option(Map("timeTaken" -> res._1, "totalRequests" -> res._2.totalRequests, "successRequests" -> res._2.successRequests, "failedRequests" -> res._2.failedRequests)));
+      JobLogger.end(s"$jobName completed execution", "SUCCESS", Option(Map("timeTaken" -> res._1, "totalRequests" -> res._2.totalRequests, "successRequests" -> res._2.successRequests, "failedRequests" -> res._2.failedRequests, "abortedRequests" -> res._2.abortedRequests)));
     } finally {
       frameworkContext.closeContext();
       spark.close()

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/BaseCollectionExhaustJob.scala
@@ -101,7 +101,7 @@ trait BaseCollectionExhaustJob extends BaseReportsJob with IJob with OnDemandExh
     val collectionBatches = getCollectionBatches(batchId, batchFilter, searchFilter, custodianOrgId, "System");
     val result: List[CollectionBatchResponse] = processBatches(userCachedDF, collectionBatches);
     result.foreach(f => JobLogger.log("Batch Status", Some(Map("status" -> f.status, "batchId" -> f.batchId, "executionTime" -> f.execTime, "message" -> f.statusMsg, "location" -> f.file)), INFO));
-    Metrics(totalRequests = Some(result.length), failedRequests = Some(result.count(x => x.status.toLowerCase() == "FAILED")), successRequests = Some(result.count(x => x.status.toLowerCase() == "SUCCESS")))
+    Metrics(totalRequests = Some(result.length), failedRequests = Some(result.count(x => x.status.toUpperCase() == "FAILED")), successRequests = Some(result.count(x => x.status.toUpperCase() == "SUCCESS")))
   }
 
   def executeOnDemand(custodianOrgId: String, userCachedDF: DataFrame)(implicit spark: SparkSession, fc: FrameworkContext, config: JobConfig): Metrics = {

--- a/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/UserInfoExhaustJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/exhaust/collection/UserInfoExhaustJob.scala
@@ -10,7 +10,7 @@ import org.sunbird.analytics.exhaust.JobRequest
 
 object UserInfoExhaustJob extends optional.Application with BaseCollectionExhaustJob with Serializable {
 
-  override def getClassName = "org.sunbird.analytics.exhaust.collection.ProgressExhaustJob"
+  override def getClassName = "org.sunbird.analytics.exhaust.collection.UserInfoExhaustJob"
   override def jobName() = "UserInfoExhaustJob";
   override def jobId() = "userinfo-exhaust";
   override def getReportPath() = "userinfo-exhaust/";


### PR DESCRIPTION
1. Added debugging logs.
2. Marking the request as "**FAILED**", while processing the request if the job got any kind of exceptions.
3. Marking the request as "**ABORTED**",  for the duplicate requests.
4. Avoided the job used set to "**PROCESSING**" status whenever it got any exception so it was blocking the execution for the same requests when it was in "**PROCESSING**" status.