### PR TITLE
SB-25287 - course batch status updater job error handling 

### DIFF
--- a/data-products/src/main/scala/org/sunbird/analytics/audit/CourseBatchStatusUpdaterJob.scala
+++ b/data-products/src/main/scala/org/sunbird/analytics/audit/CourseBatchStatusUpdaterJob.scala
@@ -5,16 +5,16 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions.{col, lit, unix_timestamp, when}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
-import org.ekstep.analytics.framework.Level.INFO
+import org.ekstep.analytics.framework.Level.{ERROR, INFO}
 import org.ekstep.analytics.framework.conf.AppConf
 import org.ekstep.analytics.framework.util.{CommonUtil, JSONUtils, JobLogger, RestUtil}
 import org.ekstep.analytics.framework.{FrameworkContext, IJob, JobConfig}
 import org.sunbird.analytics.job.report.BaseReportsJob
 import org.apache.spark.sql.cassandra._
 import org.sunbird.analytics.exhaust.collection.UDFUtils
+
 import java.text.SimpleDateFormat
 import java.util.{Calendar, Date, TimeZone}
-
 import org.apache.spark
 
 import scala.collection.immutable.List
@@ -28,15 +28,15 @@ object CourseBatchStatusUpdaterJob extends optional.Application with IJob with B
 
   // $COVERAGE-OFF$ Disabling scoverage for main and execute method
   override def main(config: String)(implicit sc: Option[SparkContext], fc: Option[FrameworkContext]): Unit = {
-    implicit val jobConfig: JobConfig = JSONUtils.deserialize[JobConfig](config)
     val jobName: String = "CourseBatchStatusUpdaterJob"
+    implicit val jobConfig: JobConfig = JSONUtils.deserialize[JobConfig](config)
     JobLogger.init(jobName)
     JobLogger.start(s"$jobName started executing", Option(Map("config" -> config, "model" -> jobName)))
     implicit val frameworkContext: FrameworkContext = getReportingFrameworkContext()
     implicit val spark: SparkSession = openSparkSession(jobConfig)
     implicit val sc: SparkContext = spark.sparkContext
-    spark.setCassandraConf("LMSCluster", CassandraConnectorConf.ConnectionHostParam.option(AppConf.getConfig("sunbird.courses.cluster.host")))
     try {
+      spark.setCassandraConf("LMSCluster", CassandraConnectorConf.ConnectionHostParam.option(AppConf.getConfig("sunbird.courses.cluster.host")))
       val res = CommonUtil.time(execute(fetchData))
       JobLogger.end(s"$jobName completed execution", "SUCCESS", Option(Map(
         "time-taken" -> res._1,
@@ -44,11 +44,15 @@ object CourseBatchStatusUpdaterJob extends optional.Application with IJob with B
         "in-progress" -> res._2.inProgress,
         "completed" -> res._2.completed
       )))
-    } finally {
+    } catch {
+      case ex: Exception =>
+        JobLogger.log(ex.getMessage, None, ERROR);
+        JobLogger.end(s"$jobName execution failed", "FAILED", Option(Map("model" -> jobName, "statusMsg" -> ex.getMessage)));
+    }
+    finally {
       frameworkContext.closeContext()
       spark.close()
     }
-
   }
 
   // $COVERAGE-ON$ Disabling scoverage for main and execute method


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25287" title="SB-25287" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />SB-25287</a>  In the portal, User can join a course only after 5:30 AM IST of the start date of the course/batch.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
… generating "FAILED" status log when the job got failed.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules